### PR TITLE
feat: POC create event form with error handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@astrojs/node": "^9.2.2",
     "@clerk/astro": "^2.9.1",
+    "@conform-to/zod": "^1.7.2",
     "@libsql/client": "^0.15.9",
     "@tailwindcss/vite": "^4.1.10",
     "astro": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/ts-plugin": "^1.10.4",
     "@biomejs/biome": "1.9.4",
+    "daisyui": "^5.0.43",
     "drizzle-kit": "^0.31.1",
     "vite-tsconfig-paths": "^5.1.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      daisyui:
+        specifier: ^5.0.43
+        version: 5.0.43
       drizzle-kit:
         specifier: ^0.31.1
         version: 0.31.1
@@ -1179,6 +1182,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  daisyui@5.0.43:
+    resolution: {integrity: sha512-2pshHJ73vetSpsbAyaOncGnNYL0mwvgseS1EWy1I9Qpw8D11OuBoDNIWrPIME4UFcq2xuff3A9x+eXbuFR9fUQ==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3718,6 +3724,8 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.1.3: {}
+
+  daisyui@5.0.43: {}
 
   data-uri-to-buffer@4.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@clerk/astro':
         specifier: ^2.9.1
         version: 2.9.1(astro@5.9.3(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.43.0)(typescript@5.8.3)(yaml@2.8.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@conform-to/zod':
+        specifier: ^1.7.2
+        version: 1.7.2(zod@3.25.67)
       '@libsql/client':
         specifier: ^0.15.9
         version: 0.15.9
@@ -205,6 +208,14 @@ packages:
   '@clerk/types@4.60.1':
     resolution: {integrity: sha512-Lbt0/Q9W9BJtGz1IITdmeqal7y1zp9EaxOEMvsTEDhOxKf/0F/M1d0gJmHEU0puQzYPp9zJsIWC2yJjbgy3Y3Q==}
     engines: {node: '>=18.17.0'}
+
+  '@conform-to/dom@1.7.2':
+    resolution: {integrity: sha512-+zhsqywrug6HoP3DXxpybjPYm3kMJ29tk1DuLD/n3JRk8uzM9UpCeSb0DuQqmhRQ5yQRsBtN5yUMzkjCB7ypmA==}
+
+  '@conform-to/zod@1.7.2':
+    resolution: {integrity: sha512-8DSMIjKwjJGdWHWRb3IHBib01Qb2Pn0C3i9May9cZlMLjxWehi1Aug+jBbTDOmmtmEpDDYnbWMjyRdBUJKQx3Q==}
+    peerDependencies:
+      zod: ^3.21.0
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -2863,6 +2874,13 @@ snapshots:
   '@clerk/types@4.60.1':
     dependencies:
       csstype: 3.1.3
+
+  '@conform-to/dom@1.7.2': {}
+
+  '@conform-to/zod@1.7.2(zod@3.25.67)':
+    dependencies:
+      '@conform-to/dom': 1.7.2
+      zod: 3.25.67
 
   '@drizzle-team/brocli@0.10.2': {}
 

--- a/src/components/Form/Field.astro
+++ b/src/components/Form/Field.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  label: string;
+  error?: (string | null) | (string | null | undefined)[];
+}
+
+const { label, error } = Astro.props;
+let errorAsArray: (string | null | undefined)[] = [];
+if (error) errorAsArray = Array.isArray(error) ? error : [error];
+---
+<div>
+  <label class="floating-label">
+    <span class="">{label}</span>
+    <slot />
+  </label>
+  {errorAsArray.filter((v) => !!v).map((err) => (
+    <span class="text-red-500 text-sm">{err}</span>
+  ))}
+</div>

--- a/src/components/Form/InputField.astro
+++ b/src/components/Form/InputField.astro
@@ -1,0 +1,20 @@
+---
+import type { ComponentProps, HTMLAttributes } from "astro/types";
+
+import Field from "./Field.astro";
+
+export interface Props
+  extends HTMLAttributes<"input">,
+    ComponentProps<typeof Field> {}
+
+const { label, error, type = "text", required = false, ...props } = Astro.props;
+---
+<Field label={label} error={error}>
+  <input
+    class="input"
+    required={required || false}
+    type={type}
+    required={required}
+    {...props}
+  />
+</Field>

--- a/src/components/Form/TextareaField.astro
+++ b/src/components/Form/TextareaField.astro
@@ -1,0 +1,19 @@
+---
+import type { ComponentProps, HTMLAttributes } from "astro/types";
+
+import Field from "./Field.astro";
+
+export interface Props
+  extends HTMLAttributes<"textarea">,
+    ComponentProps<typeof Field> {}
+
+const { label, error, required = false, ...props } = Astro.props;
+---
+<Field label={label} error={error}>
+  <textarea
+    class="textarea"
+    required={required || false}
+    required={required}
+    {...props}
+  />
+</Field>

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -1,0 +1,49 @@
+import { parseWithZod } from "@conform-to/zod";
+import { z } from "zod";
+
+type DefineFormOpts = {
+  id: string;
+};
+
+type DefineFormResult = {
+  formId: string;
+  /* Present if the form was submitted */
+  formData?: FormData;
+};
+
+export const defineForm = async (request: Request, opts: DefineFormOpts) => {
+  const result: DefineFormResult = {
+    formId: opts.id,
+  };
+
+  if (request.method === "POST") {
+    const formData = await request.formData();
+    if (formData.get("formId") === opts.id) result.formData = formData;
+  }
+
+  return result;
+};
+
+export const customZodErrorMap: z.ZodErrorMap = (issue, ctx) => {
+  if (issue.code === z.ZodIssueCode.invalid_type) {
+    if (issue.received === "undefined") {
+      return { message: "required" };
+    }
+  }
+  return { message: ctx.defaultError };
+};
+
+export const parseFormData = <Schema extends z.AnyZodObject>(
+  schema: Schema,
+  formData?: FormData
+) => {
+  if (!formData) {
+    return { status: "no_form" } as const;
+  }
+  const form = parseWithZod(formData, {
+    schema,
+    errorMap: customZodErrorMap,
+  });
+
+  return form;
+};

--- a/src/components/Form/index.ts
+++ b/src/components/Form/index.ts
@@ -35,7 +35,7 @@ export const customZodErrorMap: z.ZodErrorMap = (issue, ctx) => {
 
 export const parseFormData = <Schema extends z.AnyZodObject>(
   schema: Schema,
-  formData?: FormData
+  formData?: FormData,
 ) => {
   if (!formData) {
     return { status: "no_form" } as const;

--- a/src/modules/events/components/CreateEventForm.astro
+++ b/src/modules/events/components/CreateEventForm.astro
@@ -1,0 +1,79 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import { z } from "zod";
+import { defineForm, parseFormData } from "~/components/Form";
+import InputField from "~/components/Form/InputField.astro";
+import TextareaField from "~/components/Form/TextareaField.astro";
+
+type Props = HTMLAttributes<"form"> & {
+  id: string;
+};
+const { id, class: className, ...props } = Astro.props as Props;
+
+const { formId, formData } = await defineForm(Astro.request, { id });
+const schema = z.object({
+  formId: z.string(),
+  title: z
+    .string()
+    .min(1, "Title is required")
+    .max(200, "Title must be less than 200 characters"),
+  description: z.string().optional(),
+  date: z
+    .string()
+    .min(1, "Date is required")
+    .refine((val) => !Number.isNaN(Date.parse(val)), {
+      message: "Invalid date format",
+    }),
+  time: z
+    .string()
+    .min(1, "Time is required")
+    .refine(
+      (val) => {
+        const timeParts = val.split(":");
+        return (
+          timeParts.length === 2 &&
+          !Number.isNaN(Number(timeParts[0])) &&
+          !Number.isNaN(Number(timeParts[1]))
+        );
+      },
+      {
+        message: "Invalid time format. Use HH:MM format.",
+      },
+    ),
+});
+const form = parseFormData(schema, formData);
+
+---
+<form id={formId} method="post" class:list={["space-y-4 flex flex-col gap-2", className]} {...props}>
+    <input type="hidden" name="formId" value={formId} />
+    <InputField
+        name="title"
+        label="Event Title"
+        type="text"
+        required
+        value={form.status !== 'no_form' ? form.payload?.title as string : undefined}
+        error={form.status === 'error' ? form.error?.title : undefined}
+    />
+    <TextareaField
+        name="description"
+        label="Event Description"
+        value={form.status !== 'no_form' ? form.payload?.description as string : undefined}
+        error={form.status === 'error' ? form.error?.description : undefined}
+    />
+    <InputField
+        name="date"
+        label="Event Date"
+        type="date"
+        required
+        value={form.status !== 'no_form' ? form.payload?.date as string : undefined}
+        error={form.status === 'error' ? form.error?.date : undefined}
+    />
+    <InputField
+        name="time"
+        label="Event Time"
+        type="time"
+        value={form.status !== 'no_form' ? form.payload?.time as string : undefined}
+        error={form.status === 'error' ? form.error?.time : undefined}
+    />
+    <button type="submit" class="btn btn-primary">Create Event</button>
+</form>

--- a/src/modules/events/components/CreateEventForm.astro
+++ b/src/modules/events/components/CreateEventForm.astro
@@ -42,38 +42,37 @@ const schema = z.object({
     ),
 });
 const form = parseFormData(schema, formData);
-
 ---
 <form id={formId} method="post" class:list={["space-y-4 flex flex-col gap-2", className]} {...props}>
-    <input type="hidden" name="formId" value={formId} />
-    <InputField
-        name="title"
-        label="Event Title"
-        type="text"
-        required
-        value={form.status !== 'no_form' ? form.payload?.title as string : undefined}
-        error={form.status === 'error' ? form.error?.title : undefined}
-    />
-    <TextareaField
-        name="description"
-        label="Event Description"
-        value={form.status !== 'no_form' ? form.payload?.description as string : undefined}
-        error={form.status === 'error' ? form.error?.description : undefined}
-    />
-    <InputField
-        name="date"
-        label="Event Date"
-        type="date"
-        required
-        value={form.status !== 'no_form' ? form.payload?.date as string : undefined}
-        error={form.status === 'error' ? form.error?.date : undefined}
-    />
-    <InputField
-        name="time"
-        label="Event Time"
-        type="time"
-        value={form.status !== 'no_form' ? form.payload?.time as string : undefined}
-        error={form.status === 'error' ? form.error?.time : undefined}
-    />
-    <button type="submit" class="btn btn-primary">Create Event</button>
+  <input type="hidden" name="formId" value={formId} />
+  <InputField
+    name="title"
+    label="Event Title"
+    type="text"
+    required
+    value={form.status !== 'no_form' ? form.payload?.title as string : undefined}
+    error={form.status === 'error' ? form.error?.title : undefined}
+  />
+  <TextareaField
+    name="description"
+    label="Event Description"
+    value={form.status !== 'no_form' ? form.payload?.description as string : undefined}
+    error={form.status === 'error' ? form.error?.description : undefined}
+  />
+  <InputField
+    name="date"
+    label="Event Date"
+    type="date"
+    required
+    value={form.status !== 'no_form' ? form.payload?.date as string : undefined}
+    error={form.status === 'error' ? form.error?.date : undefined}
+  />
+  <InputField
+    name="time"
+    label="Event Time"
+    type="time"
+    value={form.status !== 'no_form' ? form.payload?.time as string : undefined}
+    error={form.status === 'error' ? form.error?.time : undefined}
+  />
+  <button type="submit" class="btn btn-primary">Create Event</button>
 </form>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,9 +1,30 @@
 ---
 import AppLayout from "~/layouts/AppLayout.astro";
 
+import CreateEventForm from "~/modules/events/components/CreateEventForm.astro";
+
 const user = await Astro.locals.currentUser();
 ---
 
 <AppLayout title="Home">
   <p>Welcome, {user?.firstName}</p>
+
+  <div class="container mx-auto my-4 max-w-[1024px] flex gap-4">
+        <div class="flex-1 basis-full md:basis-2/3">
+      <h1 class="text-2xl font-bold mb-4">Your events</h1>
+      <div class="flex flex-col gap-2">
+        <div class="card min-h-24 bg-base-200">
+        </div>
+        <div class="card min-h-24 bg-base-200">
+        </div>
+        <div class="card min-h-24 bg-base-200">
+        </div>
+      </div>
+    </div>
+    <div class="flex-1 basis-full md:basis-1/3">
+      <h1 class="text-2xl font-bold mb-4">Create a New Event</h1>
+      <CreateEventForm id="create-event-form" class="max-w-96" />
+    </div>
+  </div>
+    
 </AppLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+@plugin "daisyui";


### PR DESCRIPTION
# Description
Proof of concept to feel out form submissions/handling in astro.
- Adds `daisy-ui` as a ui / component library.
- Adds `@conform-to/zod` for form schema parsing
- Adds `Form` helpers `~/components/Form`
  - `defineForm` and `parseFormData` to help with form submission + parsing the data.
  - `Field.astro` to contain an input field in a label with a slot for error handling.
  - `InputField.astro` `TextareaField.astro`, applies `Field.astro` to the respective HTMLElement
- Adds a `CreateEventForm.astro` with error handling to create new events.
- Mock up the home-screen + add the form to test it out.

<img width="999" alt="Screenshot 2025-06-23 at 9 32 51 am" src="https://github.com/user-attachments/assets/b3319355-7d03-47c3-99eb-4534aebcb8d9" />

# How is this approach?
- It feels alright, I've erred on the side of caution regarding type-safety/inference.  I'd say for such a common pattern it'd be worth investing in better type-safety.  
  - Error map is untyped
  - Requirement to parse a `formId` to handle multiple instances of same form (not necessary for this use-case but possibly in others, I still feel like we should bake this in so there's only one system?)
  - Need to check `form.status` before accessing the fields, might be better if this was done at a field level, i.e.`<InputField value={field.value} error={field.error} />`, or better yet `<InputField field={field} />`.
  - On the other handle, remapping this data in a typesafe way is where most of the type complexity would be.  Alternative option is you could parse `<InputField form={form} name={keyof typeof form} />` and let `<Field />` contain all of the verbose `{form.status === 'error' ? form.error[name] : undefined}`.
- Annoying that it has the "resend form" notice when trying to refresh, I think for UX reasons we'll need to do something to sidestep this behaviour.
<img width="551" alt="Screenshot 2025-06-23 at 9 26 12 am" src="https://github.com/user-attachments/assets/958a6cfc-ab79-4e06-b228-7e28248c2797" />


